### PR TITLE
フッターで使用する共通のセレクトボタンの作成

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -20,5 +20,6 @@
   "files.insertFinalNewline": true,
   "files.trimTrailingWhitespace": true,
   "npm.packageManager": "yarn",
-  "typescript.enablePromptUseWorkspaceTsdk": true
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "cSpell.words": ["REGI"]
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "next": "latest",
     "react": "18.1.0",
     "react-dom": "18.1.0",
+    "react-icons": "^4.4.0",
     "remark": "^14.0.1",
     "remark-html": "^15.0.0"
   },

--- a/src/components/footer/SelectButton/index.stories.tsx
+++ b/src/components/footer/SelectButton/index.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, Story } from "@storybook/react/types-6-0";
+import { SelectButton } from "./index";
+
+export default {
+  component: SelectButton,
+  title: "footer/SelectButton",
+  parameters: {
+    backgrounds: {
+      default: "dark",
+    },
+  },
+} as Meta;
+
+const Template: Story = ({ selectType }) => (
+  <SelectButton selectType={selectType} />
+);
+
+export const selectButton = Template.bind({});
+selectButton.args = {
+  selectType: "POINT_REGI",
+};

--- a/src/components/footer/SelectButton/index.tsx
+++ b/src/components/footer/SelectButton/index.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { Box, HStack, Icon, Text } from "@chakra-ui/react";
+import { FaMapMarkerAlt } from "react-icons/fa";
+import { MdDateRange } from "react-icons/md";
+import { BsCheck } from "react-icons/bs";
+import { AiFillQuestionCircle } from "react-icons/ai";
+import { IconType } from "react-icons/lib";
+
+type Props = {
+  selectType: "POINT_REGI" | "DATE_REGI" | "OTHERS";
+};
+
+export const SelectButton = ({ selectType }: Props) => {
+  // 使用されることは無いが iconPath の null を避けるための初期値
+  let iconPath: IconType = AiFillQuestionCircle;
+  let title = "NO DATA";
+
+  switch (selectType) {
+    case "POINT_REGI":
+      iconPath = FaMapMarkerAlt;
+      title = "地点登録";
+      break;
+    case "DATE_REGI":
+      iconPath = MdDateRange;
+      title = "予定日登録";
+      break;
+    case "OTHERS":
+      iconPath = BsCheck;
+      title = "その他";
+      break;
+    default:
+      break;
+  }
+
+  return (
+    <Box w={100} color="blue.400">
+      <HStack>
+        <Icon as={iconPath} />
+        <Box>
+          <Text fontSize="xs">{title}</Text>
+        </Box>
+      </HStack>
+    </Box>
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -9902,6 +9902,11 @@ react-focus-lock@^2.9.1:
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
 
+react-icons@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-4.4.0.tgz#a13a8a20c254854e1ec9aecef28a95cdf24ef703"
+  integrity sha512-fSbvHeVYo/B5/L4VhB7sBA1i2tS8MkT0Hb9t2H1AVPkwGfVHLJCqyr2Py9dKMxsyM63Eng1GkdZfbWj+Fmv8Rg==
+
 react-inspector@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/react-inspector/-/react-inspector-5.1.1.tgz#58476c78fde05d5055646ed8ec02030af42953c8"


### PR DESCRIPTION
## 🔨 変更内容
- フッターで使用する共通のセレクトボタンの作成
- この Issue では、フッターで使用するセレクトボタンの部分を切り抜いてコンポーネントを作成した

## 📸 スクリーンショット
![issue](https://user-images.githubusercontent.com/68209431/172765404-71d63740-1b4c-4dd8-a9d9-7a52626b01d0.gif)


## ✅ 解決するイシュー
- close #14

## 🤝 関連するイシュー
- #14
